### PR TITLE
jihobak#2 'save_history_of'의 'start_date' 초기값을 바꿈

### DIFF
--- a/BigBull/crawler/history_crawler.py
+++ b/BigBull/crawler/history_crawler.py
@@ -283,7 +283,7 @@ class HistoryCrawler(BaseCrawler):
     #  - INSERT 한다.
     """
 
-    def save_history_of(self, company_name, start_date=datetime.datetime.min,
+    def save_history_of(self, company_name, start_date="1956-3-3",
                         end_date=datetime.datetime.today,
                         hard_mode=True):
         """


### PR DESCRIPTION
#2 

error related with pandas
```OutOfBoundsDatetime: Out of bounds nanosecond timestamp: 1-01-01 00:00:00```

start_date의 초기값 datetime.datetime.min이 pandas datetime 으로 바뀌면서 생기는 문제여서 
초기값을 1956년 3월 3일 대한증권거래소가 출범한 날짜로 설정.
